### PR TITLE
Add custom reporters

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -88,6 +88,21 @@ module.exports = function( grunt ){
                 files: {
                     src: [ 'test/fixtures/errors.less' ]
                 }
+            },
+            customReporter: {
+                files: {
+                    src: [ 'test/fixtures/**/*.less' ]
+                },
+                options: {
+                    reporter: {
+                        name: "test-reporter",
+                        report: function(errors) {
+                            errors.forEach(function(error) {
+                                console.log("custom " + error.linter);
+                            });
+                        }
+                    }
+                }
             }
         },
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,36 @@ Default value: `false`
 
 Set `force` to `true` to report lesshint errors but not fail the task.
 
+#### reporter
+Type: `Object`
+
+Refer to the lesshint docs for more examples: https://github.com/lesshint/lesshint#writing-your-own-reporter
+Define your own custom reporter:
+
+```javascript
+options {
+    reporter: {
+        name: "foo-reporter", // optional but recommended
+        report: function(errors) {
+            errors.forEach(function(error) {
+                console.log(error);
+                // error object looks like:
+                // {
+                //     column: 5,
+                //     file: 'file.less',
+                //     fullPath: 'path/to/file.less',
+                //     line: 1,
+                //     linter: 'spaceBeforeBrace',
+                //     message: 'Opening curly brace should be preceded by one space.',
+                //     severity: 'warning',
+                //     source: '.foo{'
+                // }
+            });
+        }
+    }
+}
+```
+
 #### lesshintrc
 
 Type: `String` or `true`  

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "devDependencies": {
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-mocha-test": "^0.12.7",
+    "mocha": "^1.20.0",
     "spawn-sync": "^1.0.13"
   },
   "keywords": [

--- a/tasks/lesshint.js
+++ b/tasks/lesshint.js
@@ -46,22 +46,29 @@ module.exports = function( grunt ){
             try {
                 files.src.forEach( function( filepath ){
                     var input = grunt.file.read( filepath ),
-                        output = linter.checkString( input, '' ),
+                        output = linter.checkString( input, filepath ),
                         inputArray;
 
-                    if( output.length > 0 ){
-                        errorFileCount = errorFileCount + 1;
-                        inputArray = input.toString().split( '\n' );
+                    if( output.length > 0 ) {
+                        if (options.reporter && options.reporter.report) {
+                            // use custom reporter if there
+                            options.reporter.report(output);
+                        } else {
+                            // use built in reporter
+                            errorFileCount = errorFileCount + 1;
+                            inputArray = input.toString().split( '\n' );
 
-                        grunt.log.writeln();
-                        grunt.log.subhead( '  ' + filepath );
-                        output.forEach( function( errorObject ){
-                            errorCount = errorCount + 1;
-                            grunt.log.writeln( '    ' + errorObject.line + ' | ' + chalk.gray( inputArray[ errorObject.line - 1 ] ) );
-                            grunt.log.writeln( grunt.util.repeat( errorObject.column + 7, ' ' ) + '^ ' + errorObject.message );
-                        });
+                            grunt.log.writeln();
+                            grunt.log.subhead( '  ' + filepath );
+                            output.forEach( function( errorObject ){
+                                errorCount = errorCount + 1;
+                                grunt.log.writeln( '    ' + errorObject.line + ' | ' + chalk.gray( inputArray[ errorObject.line - 1 ] ) );
+                                grunt.log.writeln( grunt.util.repeat( errorObject.column + 7, ' ' ) + '^ ' + errorObject.message );
+                            });
 
-                        grunt.log.writeln();
+                            grunt.log.writeln();
+                        }
+
                     } else {
                         cleanFileCount = cleanFileCount + 1;
                     }

--- a/tasks/lesshint.js
+++ b/tasks/lesshint.js
@@ -53,6 +53,8 @@ module.exports = function( grunt ){
                         if (options.reporter && options.reporter.report) {
                             // use custom reporter if there
                             options.reporter.report(output);
+                            errorFileCount += 1;
+                            errorCount += output.length;
                         } else {
                             // use built in reporter
                             errorFileCount = errorFileCount + 1;

--- a/test/grunt-lesshint.js
+++ b/test/grunt-lesshint.js
@@ -57,4 +57,15 @@ describe( 'grunt-lesshint', function(){
             assert.equal( response.status, 0 );
         });
     });
+
+    describe( 'customReporter', function(){
+        var response = spawnSync( 'node', [ gruntPath, 'lesshint:customReporter' ], {
+            encoding: 'utf8'
+        });
+
+        it( 'This assertion should use custom reporter to log error', function() {
+            assert(response.stdout.indexOf("custom spaceBeforeBrace") >= 0);
+            assert(response.stdout.indexOf("custom spaceAfterPropertyColon") >= 0);
+        });
+    });
 });

--- a/test/grunt-lesshint.js
+++ b/test/grunt-lesshint.js
@@ -64,6 +64,7 @@ describe( 'grunt-lesshint', function(){
         });
 
         it( 'This assertion should use custom reporter to log error', function() {
+            assert.equal( response.status, 3 );
             assert(response.stdout.indexOf("custom spaceBeforeBrace") >= 0);
             assert(response.stdout.indexOf("custom spaceAfterPropertyColon") >= 0);
         });


### PR DESCRIPTION
This allows specifying custom reporters to use instead of the one built into `grunt-lesshint`.

An example reporter would be:
```javascript
options: {
    reporter: {
        name: "test-reporter",
        report: function(errors) {
            errors.forEach(function(error) {
                console.log("custom " + error.linter);
            });
        }
    }
}
```
This follows the specification of the `lesshint` module itself. Tests included also.