### PR TITLE
Adding support for warnings so that only errors will cause a task to fail

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -74,8 +74,12 @@ module.exports = function( grunt ){
             },
             customOptions: {
                 options: {
-                    spaceAfterPropertyColon: 'no_space',
-                    spaceBeforeBrace: 'no_space'
+                    spaceAfterPropertyColon: {
+                        style: 'no_space'
+                    },
+                    spaceBeforeBrace: {
+                        style: 'no_space'
+                    }
                 },
                 files: {
                     src: [ 'test/fixtures/errors.less' ]
@@ -102,6 +106,29 @@ module.exports = function( grunt ){
                             });
                         }
                     }
+                }
+            },
+            allowWarnings: {
+                options: {
+                    allowWarnings: true,
+                    spaceAfterPropertyColon: {
+                        style: 'one_space'
+                    }
+                },
+                files: {
+                    src: [ 'test/fixtures/warnings.less' ]
+                }
+            },
+            allowWarningsWithError: {
+                options: {
+                    allowWarnings: true,
+                    spaceAfterPropertyColon: {
+                        style: 'one_space',
+                        severity: "error"
+                    }
+                },
+                files: {
+                    src: [ 'test/fixtures/warnings.less' ]
                 }
             }
         },

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ If a filename is specified, options and globals defined therein will be used. Th
 }
 ```
 
+#### allowWarnings
+Type: `Boolean`  
+Default value: `false`
+
+Set `allowWarnings` to `true` to allow the task to succeed if only warnings occur.
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 

--- a/tasks/lesshint.js
+++ b/tasks/lesshint.js
@@ -105,7 +105,9 @@ module.exports = function( grunt ){
 
                 grunt.log.warn( response );
 
-                if (errorCount > 0) {
+                if (options.allowWarnings === true && errorCount === 0) {
+                    success = true;
+                } else {
                     success = false;
                 }
             } else {

--- a/tasks/lesshint.js
+++ b/tasks/lesshint.js
@@ -37,6 +37,7 @@ module.exports = function( grunt ){
             var errorCount = 0,
                 errorFileCount = 0,
                 cleanFileCount = 0,
+                warningCount = 0,
                 response;
 
             if( !files.src.length ){
@@ -54,7 +55,13 @@ module.exports = function( grunt ){
                             // use custom reporter if there
                             options.reporter.report(output);
                             errorFileCount += 1;
-                            errorCount += output.length;
+                            output.forEach(function (reportObject) {
+                                if (reportObject.severity === "error") {
+                                    errorCount = errorCount + 1;
+                                } else {
+                                    warningCount = warningCount + 1;
+                                }
+                            });
                         } else {
                             // use built in reporter
                             errorFileCount = errorFileCount + 1;
@@ -62,10 +69,15 @@ module.exports = function( grunt ){
 
                             grunt.log.writeln();
                             grunt.log.subhead( '  ' + filepath );
-                            output.forEach( function( errorObject ){
-                                errorCount = errorCount + 1;
-                                grunt.log.writeln( '    ' + errorObject.line + ' | ' + chalk.gray( inputArray[ errorObject.line - 1 ] ) );
-                                grunt.log.writeln( grunt.util.repeat( errorObject.column + 7, ' ' ) + '^ ' + errorObject.message );
+                            output.forEach(function (reportObject) {
+                                if (reportObject.severity === "error") {
+                                    errorCount = errorCount + 1;
+                                } else {
+                                    warningCount = warningCount + 1;
+                                }
+
+                                grunt.log.writeln( '    ' + reportObject.line + ' | ' + chalk.gray( inputArray[ reportObject.line - 1 ] ) );
+                                grunt.log.writeln( grunt.util.repeat( reportObject.column + 7, ' ' ) + '^ ' + reportObject.message );
                             });
 
                             grunt.log.writeln();
@@ -79,8 +91,11 @@ module.exports = function( grunt ){
                 grunt.fail.fatal( error );
             }
 
-            if( errorCount > 0 ){
-                response = errorCount + grunt.util.pluralize( errorCount, ' error in / errors in ' ) + errorFileCount + grunt.util.pluralize( errorFileCount, ' file/ files' );
+            if (warningCount > 0 || errorCount > 0) {
+                response =
+                    warningCount + grunt.util.pluralize(errorCount, ' warning/ warnings') +
+                    " and " + errorCount + grunt.util.pluralize(errorCount, ' error in / errors in ') +
+                    errorFileCount + grunt.util.pluralize(errorFileCount, ' file/ files');
 
                 if( cleanFileCount > 0 ){
                     response = response + ' and ' + cleanFileCount + grunt.util.pluralize( cleanFileCount, ' clean file./ clean files.' );
@@ -90,7 +105,9 @@ module.exports = function( grunt ){
 
                 grunt.log.warn( response );
 
-                success = false;
+                if (errorCount > 0) {
+                    success = false;
+                }
             } else {
                 grunt.log.ok( cleanFileCount + grunt.util.pluralize( cleanFileCount, ' file / files ' ) + 'without linting errors.' );
             }

--- a/test/fixtures/warnings.less
+++ b/test/fixtures/warnings.less
@@ -1,0 +1,3 @@
+div {
+    test:false;
+}

--- a/test/grunt-lesshint.js
+++ b/test/grunt-lesshint.js
@@ -69,4 +69,24 @@ describe( 'grunt-lesshint', function(){
             assert(response.stdout.indexOf("custom spaceAfterPropertyColon") >= 0);
         });
     });
+
+    describe( 'allowWarnings', function(){
+        var response = spawnSync( 'node', [ gruntPath, 'lesshint:allowWarnings' ], {
+            encoding: 'utf8'
+        });
+
+        it( 'This assertion should succeed and exit with status code 0 (No errors!)', function(){
+            assert.equal( response.status, 0 );
+        });
+    });
+
+    describe( 'allowWarningsWithError', function(){
+        var response = spawnSync( 'node', [ gruntPath, 'lesshint:allowWarningsWithError' ], {
+            encoding: 'utf8'
+        });
+
+        it( 'This assertion should exit with status code 3 (Task error)', function(){
+            assert.equal( 3, response.status );
+        } );
+    });
 });


### PR DESCRIPTION
The current task will fail if any warnings are returned from linting. These changes will ensure that the task will only fail if an error is returned from linting.

The new output message will be:

```
3 warnings and 2 errors in 3 files and 114 clean files.
```

The new behaviour is opt-in so the user will be required to set `allowWarnings` to `true` in order for the new behaviour to take effect.